### PR TITLE
Give player credit for guesses that are only off by one letter.

### DIFF
--- a/controller.rb
+++ b/controller.rb
@@ -29,6 +29,11 @@ class Controller
       if input == current_card.term.downcase
         view.display_message(:right)
         correct = true
+      elsif off_by_one(input, current_card.term.downcase)
+        view.display_message(:off_by_one)
+        view.display_term(current_card)
+        correct = true
+        view.display_message(:skip)
       elsif input == "give up"
         view.display_message(:give_up)
         view.display_term(current_card)
@@ -42,6 +47,28 @@ class Controller
       end
     end
     input
+  end
+
+  # check if a string is one character off from another string
+  def off_by_one(guess, answer)
+    string_a, string_b = [guess, answer].sort_by { |string| string.length }
+    length_diff = string_b.length - string_a.length 
+    # if length differs by one character, try removing each
+    # character of the longer string one by one to see if any
+    # versions match.
+    if length_diff == 1
+      string_b.length.times.any? do |index|
+        string_b[0...index] + string_b[(index+1)..-1] == string_a
+      end
+    # if length is the same, compare letter by letter and
+    # see if the number of differences is one or less
+    elsif length_diff == 0
+      string_a.length.times.count { |i| string_a[i] != string_b[i] } <= 1
+    # if length difference is greater than one, the strings 
+    # can't be off by one
+    else
+      false
+    end
   end
 
   attr_reader :view, :deck

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -24,18 +24,41 @@ end
 
 describe "Controller" do
   let(:messages) { View.new.messages }
+  let(:cls) {"\e[H\e[2J"}
   let(:deck_file) { "spec/test_deck.txt" }
   let(:empty_deck_file) { "spec/empty_deck.txt" }
   let(:controller) { Controller.new(deck_file) }
   let(:controller_empty_deck) { Controller.new(empty_deck_file) }
 
-  describe "run"
+  describe "run" do
     it 'should quit when you pass an empty deck' do
-       expect{controller_empty_deck.run}.to output(messages[:hello]+messages[:goodbye]+"\n").to_stdout
+       expect{controller_empty_deck.run}.to output("#{cls}\n#{messages[:hello]}\n#{messages[:goodbye]}\n\n").to_stdout
     end
 
     it 'should quit when you type quit' do
        controller.view.fake_input = ["quit"]
-       expect{controller.run}.to output(/#{messages[:goodbye]+"\n"}$/).to_stdout
+       expect{controller.run}.to output(/#{messages[:goodbye]+"\n\n"}$/).to_stdout
     end
+  end
+
+  describe "#off_by_one" do
+    it "should return true when words match or are off by one" do
+      expect(controller.send(:off_by_one, "dog","doug")).to be true
+      expect(controller.send(:off_by_one, "cat","cat")).to be true
+      expect(controller.send(:off_by_one, "pizza","piza")).to be true
+      expect(controller.send(:off_by_one, "orange","oranges")).to be true
+      expect(controller.send(:off_by_one, "number","nunber")).to be true
+      expect(controller.send(:off_by_one, "if","of")).to be true
+      expect(controller.send(:off_by_one, "quiz","quid")).to be true
+    end
+
+    it "should return false when words are off by more than one" do 
+      expect(controller.send(:off_by_one, "dog","god")).to be false
+      expect(controller.send(:off_by_one, "mince","mints")).to be false
+      expect(controller.send(:off_by_one, "soul","sole")).to be false
+      expect(controller.send(:off_by_one, "spear","clear")).to be false
+      expect(controller.send(:off_by_one, "taco","talon")).to be false
+    end
+  end
+
 end

--- a/view.rb
+++ b/view.rb
@@ -11,7 +11,8 @@ Type 'give up' to see the answer.
     right: "Correct! Good job!",
     wrong: "Please try again.",
     skip: "Okay. Moving on...",
-    give_up: "Here is the answer: "
+    give_up: "Here is the answer: ",
+    off_by_one: "Close enough! The answer was:"
   }
 
   def get_input


### PR DESCRIPTION
@maggiedbaker 
The game now gives credit for guesses that are off by one. This includes guesses with one letter more, one letter less, or one letter different than the correct answer.

i.e. "pizzas" "piza" and "pitza" would all match for "pizza" :pizza: 

When the player is off by one, the game counts the guess as correct, shows the player the correctly spelled answer, and then moves to the next card.

I also fixed a few broken rspec tests for the controller while I was adding tests for my off_by_one method.
